### PR TITLE
[TS] LPS-120425 | Date picker shows year as 'y' when using JDK11 for language Arabic/Laos/Persian/Slovenian

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_date/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_date/page.jsp
@@ -58,11 +58,12 @@ if (!BrowserSnifferUtil.isMobile(request)) {
 
 	simpleDateFormatPattern = shortDateFormatSimpleDateFormat.toPattern();
 
-	simpleDateFormatPattern = simpleDateFormatPattern.replaceAll("yyyy", "yy");
+	simpleDateFormatPattern = simpleDateFormatPattern.replaceAll("yyyy", "y");
+	simpleDateFormatPattern = simpleDateFormatPattern.replaceAll("yy", "y");
 	simpleDateFormatPattern = simpleDateFormatPattern.replaceAll("MM", "M");
 	simpleDateFormatPattern = simpleDateFormatPattern.replaceAll("dd", "d");
 
-	simpleDateFormatPattern = simpleDateFormatPattern.replaceAll("yy", "yyyy");
+	simpleDateFormatPattern = simpleDateFormatPattern.replaceAll("y", "yyyy");
 	simpleDateFormatPattern = simpleDateFormatPattern.replaceAll("M", "MM");
 	simpleDateFormatPattern = simpleDateFormatPattern.replaceAll("d", "dd");
 


### PR DESCRIPTION
Description:
Date picker shows year as 'y' when using JDK11 for language Arabic/Laos/Persian/Slovenian

Steps to reproduce:
1. Use JRE/JDK 11 for the reproduction
2. Start a master bundle
3. Set the user's language to Arabic/Laos/Persian/Slovenian
4. Set the user's birthday by clicking on the date field

Before this PR: Year is shown as 'y', can't set any other year than 2020
After this PR: Year should be shown with numbers, should be able to set any date

For more details: https://issues.liferay.com/browse/LPS-120425