### PR TITLE
[TS] LPS-121529 | Fix wiki search results are not being marked by keywords

### DIFF
--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
@@ -215,6 +215,19 @@ public class WikiPageIndexer
 	}
 
 	@Override
+	public Hits search(SearchContext searchContext) throws SearchException {
+		Hits hits = super.search(searchContext);
+
+		String[] queryTerms = ArrayUtil.append(
+			GetterUtil.getStringValues(hits.getQueryTerms()),
+			StringUtil.split(searchContext.getKeywords(), StringPool.SPACE));
+
+		hits.setQueryTerms(queryTerms);
+
+		return hits;
+	}
+
+	@Override
 	public void updateFullQuery(SearchContext searchContext) {
 	}
 
@@ -456,19 +469,6 @@ public class WikiPageIndexer
 				_deleteDocument(wikiPage);
 			}
 		}
-	}
-
-	@Override
-	public Hits search(SearchContext searchContext) throws SearchException {
-		Hits hits = super.search(searchContext);
-
-		String[] queryTerms = ArrayUtil.append(
-			GetterUtil.getStringValues(hits.getQueryTerms()),
-			StringUtil.split(searchContext.getKeywords(), StringPool.SPACE));
-
-		hits.setQueryTerms(queryTerms);
-
-		return hits;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
@@ -15,6 +15,7 @@
 package com.liferay.wiki.internal.search;
 
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.comment.Comment;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
@@ -461,7 +462,10 @@ public class WikiPageIndexer
 	public Hits search(SearchContext searchContext) throws SearchException {
 		Hits hits = super.search(searchContext);
 
-		String[] queryTerms = StringUtil.split(searchContext.getKeywords(), " ");
+		String[] queryTerms = ArrayUtil.append(
+			GetterUtil.getStringValues(hits.getQueryTerms()),
+			StringUtil.split(searchContext.getKeywords(), StringPool.SPACE));
+
 		hits.setQueryTerms(queryTerms);
 
 		return hits;

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
@@ -50,6 +51,7 @@ import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.trash.TrashHelper;
@@ -453,6 +455,16 @@ public class WikiPageIndexer
 				_deleteDocument(wikiPage);
 			}
 		}
+	}
+
+	@Override
+	public Hits search(SearchContext searchContext) throws SearchException {
+		Hits hits = super.search(searchContext);
+
+		String[] queryTerms = StringUtil.split(searchContext.getKeywords(), " ");
+		hits.setQueryTerms(queryTerms);
+
+		return hits;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
Fix wiki search results are not being marked by keywords
Steps to reproduce:
1. Add wiki widget to the page
2. Add new wiki with text "Search this highlight-text" 
3. Search highlight-text using search input from wiki 
4. Check search results, see keywords not being marked