### PR TITLE
[TECHNICAL SUPPORT] LPS-135460 delta parameter is missing from the url if pagination is done trough combo box

### DIFF
--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -202,12 +202,13 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 							}
 
 							for (int i = pagesIteratorBegin; i <= pagesIteratorEnd; i++) {
+								String curParamUrl = HttpUtil.setParameter(url + urlAnchor, namespace + curParam, i);
 							%>
 
 								<liferay-ui:icon
 									message="<%= String.valueOf(i) %>"
 									onClick='<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>'
-									url='<%= HtmlUtil.escapeJSLink(url.split(namespace)[0] + namespace + curParam + "=" + i + urlAnchor) %>'
+									url="<%= HtmlUtil.escapeJSLink(curParamUrl) %>"
 								/>
 
 							<%


### PR DESCRIPTION
Hey,

[LPS-135460](https://issues.liferay.com/browse/LPS-135460),
This issue is a regression of [LPS-134536](https://issues.liferay.com/browse/LPS-134536), In case of the asset publisher we store the delta parameter in the portlet configuration, however with the changes introduced in LPS-134546, I stripped down the delta parameter from the url, and it causes issues in simple scenarios, where a customer is using this taglib in their custom portlet.

I reworked the solution to update the parameter in the url instead of stripping it completely, please  review my changes

Thanks,