### PR TITLE
LPS-135935 Override calendarbase header template to meet accessibility criteria

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
@@ -672,7 +672,7 @@
 	}
 
 	.yui3-calendar-weekday {
-		color: #4599e2;
+		color: #367bb6;
 	}
 
 	.yui3-calendar-day {

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_base_override.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_base_override.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+AUI.add('liferay-calendar-base-override', (A) => {
+	var temp = document.createElement('DIV');
+	temp.innerHTML = A.CalendarBase.HEADER_TEMPLATE;
+	var lastNode = temp.childNodes[temp.childNodes.length - 1];
+	var lastNodeHTML = lastNode.innerHTML;
+	lastNodeHTML = lastNodeHTML
+		.replace('aria-role="heading"', '')
+		.replace('<div', '<h1')
+		.replace('</div>', '</h1>');
+	lastNode.innerHTML = lastNodeHTML;
+
+	A.CalendarBase.HEADER_TEMPLATE = temp.innerHTML;
+});

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/config.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/config.js
@@ -20,6 +20,9 @@
 				combine: Liferay.AUI.getCombine(),
 				filter: Liferay.AUI.getFilterConfig(),
 				modules: {
+					'liferay-calendar-base-override': {
+						path: 'calendar_base_override.js',
+					},
 					'liferay-calendar-container': {
 						path: 'calendar_container.js',
 						requires: [
@@ -121,6 +124,7 @@
 							'aui-datatype',
 							'aui-scheduler',
 							'dd-plugin',
+							'liferay-calendar-base-override',
 							'liferay-calendar-message-util',
 							'liferay-calendar-recurrence-converter',
 							'liferay-calendar-recurrence-util',


### PR DESCRIPTION
Hi @georgel-pop-lr ,

Accessibility tool (Accessibility Insights for Web) detected error on minicalendar heading element and insufficient color contrast on the weekdays.
The header template is actually coming from the YUI library, but since that was not updated for a long time and the fix is small, I was advised to override the template in the calendar-web module.
LPS: https://issues.liferay.com/browse/LPS-135935

Please review. Thanks!
