### PR TITLE
[TS] LPS-142123 Empty button and link error on widget and content page - accessibility

### DIFF
--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/java/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/SimulationProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/java/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/SimulationProductNavigationControlMenuEntry.java
@@ -233,6 +233,7 @@ public class SimulationProductNavigationControlMenuEntry
 
 			IconTag iconTag = new IconTag();
 
+			iconTag.setAriaLabel("Close");
 			iconTag.setCssClass("close sidenav-close");
 			iconTag.setImage("times");
 			iconTag.setMarkupView("lexicon");

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/view.jsp
@@ -27,6 +27,7 @@ String analyticsReportsPanelState = SessionClicks.get(request, "com.liferay.anal
 		<span class="font-weight-bold"><liferay-ui:message key="content-performance" /></span>
 
 		<clay:button
+			aria-label="Close"
 			cssClass="sidenav-close text-secondary"
 			displayType="unstyled"
 			icon="times"

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/view.jsp
@@ -23,6 +23,7 @@
 		<span class="font-weight-bold"><liferay-ui:message key="ab-test" /></span>
 
 		<clay:button
+			aria-label="Close"
 			cssClass="sidenav-close text-secondary"
 			displayType="unstyled"
 			icon="times"

--- a/util-taglib/bnd.bnd
+++ b/util-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 8.1.4
+Bundle-Version: 8.2.0
 Export-Package:\
 	com.liferay.alloy.taglib.*;version="3.0.0",\
 	com.liferay.taglib.*

--- a/util-taglib/src/META-INF/liferay-aui.tld
+++ b/util-taglib/src/META-INF/liferay-aui.tld
@@ -16,6 +16,12 @@
 		<tag-class>com.liferay.taglib.aui.ATag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
+			<description><![CDATA[A name for the navigation component for assistive technologies to interpret.]]></description>
+			<name>ariaLabel</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description><![CDATA[A role for assistive technologies to interpret HTML elements that have been used for something other than their intended purpose. For example, the <code>&lt;p&gt;</code> tag could be used for something other than a paragraph.]]></description>
 			<name>ariaRole</name>
 			<required>false</required>

--- a/util-taglib/src/com/liferay/taglib/aui/ATag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/ATag.java
@@ -87,6 +87,7 @@ public class ATag extends BaseATag {
 	protected int processStartTag() throws Exception {
 		JspWriter jspWriter = pageContext.getOut();
 
+		String ariaLabel = getAriaLabel();
 		String ariaRole = getAriaRole();
 		String cssClass = getCssClass();
 		Map<String, Object> data = getData();
@@ -115,6 +116,12 @@ public class ATag extends BaseATag {
 		}
 		else {
 			jspWriter.write("<span ");
+		}
+
+		if (Validator.isNotNull(ariaLabel)) {
+			jspWriter.write("aria-label=\"");
+			jspWriter.write(ariaLabel);
+			jspWriter.write("\" ");
 		}
 
 		if (Validator.isNotNull(cssClass)) {

--- a/util-taglib/src/com/liferay/taglib/aui/IconTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/IconTag.java
@@ -95,6 +95,7 @@ public class IconTag extends BaseIconTag {
 		else {
 			ATag aTag = new ATag();
 
+			aTag.setAriaLabel(getAriaLabel());
 			aTag.setCssClass(getCssClass());
 			aTag.setData(getData());
 			aTag.setHref(getUrl());

--- a/util-taglib/src/com/liferay/taglib/aui/base/BaseATag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/base/BaseATag.java
@@ -32,6 +32,10 @@ public abstract class BaseATag extends com.liferay.taglib.util.IncludeTag {
 		return super.doStartTag();
 	}
 
+	public java.lang.String getAriaLabel() {
+		return _ariaLabel;
+	}
+
 	public java.lang.String getAriaRole() {
 		return _ariaRole;
 	}
@@ -78,6 +82,10 @@ public abstract class BaseATag extends com.liferay.taglib.util.IncludeTag {
 
 	public java.lang.String getTitle() {
 		return _title;
+	}
+
+	public void setAriaLabel(java.lang.String ariaLabel) {
+		_ariaLabel = ariaLabel;
 	}
 
 	public void setAriaRole(java.lang.String ariaRole) {
@@ -132,6 +140,7 @@ public abstract class BaseATag extends com.liferay.taglib.util.IncludeTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
+		_ariaLabel = null;
 		_ariaRole = null;
 		_cssClass = null;
 		_data = null;
@@ -164,6 +173,7 @@ public abstract class BaseATag extends com.liferay.taglib.util.IncludeTag {
 	private static final String _START_PAGE =
 		"/html/taglib/aui/a/start.jsp";
 
+	private java.lang.String _ariaLabel = null;
 	private java.lang.String _ariaRole = null;
 	private java.lang.String _cssClass = null;
 	private java.util.Map<java.lang.String, java.lang.Object> _data = null;

--- a/util-taglib/src/com/liferay/taglib/aui/base/BaseIconTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/base/BaseIconTag.java
@@ -33,6 +33,10 @@ public abstract class BaseIconTag extends com.liferay.taglib.util.IncludeTag {
 		return super.doStartTag();
 	}
 
+	public java.lang.String getAriaLabel() {
+		return _ariaLabel;
+	}
+
 	public java.lang.String getCssClass() {
 		return _cssClass;
 	}
@@ -67,6 +71,10 @@ public abstract class BaseIconTag extends com.liferay.taglib.util.IncludeTag {
 
 	public java.lang.String getUrl() {
 		return _url;
+	}
+
+	public void setAriaLabel(java.lang.String ariaLabel) {
+		_ariaLabel = ariaLabel;
 	}
 
 	public void setCssClass(java.lang.String cssClass) {
@@ -109,6 +117,7 @@ public abstract class BaseIconTag extends com.liferay.taglib.util.IncludeTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
+		_ariaLabel = null;
 		_cssClass = null;
 		_data = null;
 		_id = null;
@@ -127,6 +136,7 @@ public abstract class BaseIconTag extends com.liferay.taglib.util.IncludeTag {
 
 	@Override
 	protected void setAttributes(HttpServletRequest request) {
+		setNamespacedAttribute(request, "ariaLabel", _ariaLabel);
 		setNamespacedAttribute(request, "cssClass", _cssClass);
 		setNamespacedAttribute(request, "data", _data);
 		setNamespacedAttribute(request, "id", _id);
@@ -143,6 +153,7 @@ public abstract class BaseIconTag extends com.liferay.taglib.util.IncludeTag {
 	private static final String _PAGE =
 		"/html/taglib/aui/icon/page.jsp";
 
+	private java.lang.String _ariaLabel = null;
 	private java.lang.String _cssClass = null;
 	private java.util.Map<java.lang.String, java.lang.Object> _data = null;
 	private java.lang.String _id = null;

--- a/util-taglib/src/com/liferay/taglib/aui/base/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/aui/base/packageinfo
@@ -1,1 +1,1 @@
-version 11.1.0
+version 11.2.0

--- a/util-taglib/src/com/liferay/taglib/aui/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/aui/packageinfo
@@ -1,1 +1,1 @@
-version 11.1.0
+version 11.2.0


### PR DESCRIPTION
Hi @georgel-pop-lr ,

https://issues.liferay.com/browse/LPS-142123
The issue is that Wave accessibility tool detected empty button and empty links on Widget and Content page.
I have added aria-label attribute to the elements.

Please review my changes,
Thank you!
