### PR TITLE
[TS] LPS-145240 Remove unused look.and.feel.modifiable portal property

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1580,10 +1580,6 @@ public class PropsValues {
 	public static final String[] LOGOUT_EVENTS_PRE = PropsUtil.getArray(
 		PropsKeys.LOGOUT_EVENTS_PRE);
 
-	public static final boolean LOOK_AND_FEEL_MODIFIABLE =
-		GetterUtil.getBoolean(
-			PropsUtil.get(PropsKeys.LOOK_AND_FEEL_MODIFIABLE));
-
 	public static final String MAIL_AUDIT_TRAIL = PropsUtil.get(
 		PropsKeys.MAIL_AUDIT_TRAIL);
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3066,14 +3066,6 @@
 ##
 
     #
-    # Set this to false if the system does not allow users to modify the look
-    # and feel.
-    #
-    # Env: LIFERAY_LOOK_PERIOD_AND_PERIOD_FEEL_PERIOD_MODIFIABLE
-    #
-    look.and.feel.modifiable=true
-
-    #
     # Set the default layout template ID.
     #
     # Env: LIFERAY_DEFAULT_PERIOD_LAYOUT_PERIOD_TEMPLATE_PERIOD_ID

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1833,9 +1833,6 @@ public interface PropsKeys {
 
 	public static final String LOGOUT_EVENTS_PRE = "logout.events.pre";
 
-	public static final String LOOK_AND_FEEL_MODIFIABLE =
-		"look.and.feel.modifiable";
-
 	public static final String MAIL_AUDIT_TRAIL = "mail.audit.trail";
 
 	public static final String MAIL_BATCH_SIZE = "mail.batch.size";


### PR DESCRIPTION
Hi @georgel-pop-lr ,
I removed "**look.and.feel.modifiable**" portal property since I have not found it anywhere to be used on the code level.

LPS: https://issues.liferay.com/browse/LPS-145240

The reason why this came up is because of a BLADE upgradeProps command during upgrading which analyzes the old portal-ext.properties and the newly installed 7.x server to show the properties moved to OSGi configuration files or removed from the product. (https://help.liferay.com/hc/en-us/articles/360029147071-Blade-CLI)
The command asked for the property, however, it seems to be unused in the Portal, hence causing confusion.
Looking into history, I have not found anything for the replacement of this property or the reason why it is not used anymore.

Could you please review it?
Thank you!