### PR TITLE
LPD-94450 wip

### DIFF
--- a/modules/apps/audiences/audiences-web/package.json
+++ b/modules/apps/audiences/audiences-web/package.json
@@ -1,11 +1,15 @@
 {
 	"dependencies": {
 		"@clayui/button": "^3.165.0",
+		"@clayui/empty-state": "^3.165.0",
 		"@clayui/form": "^3.165.0",
 		"@clayui/icon": "^3.165.0",
 		"@clayui/layout": "^3.165.0",
 		"@clayui/link": "^3.165.0",
+		"@clayui/list": "^3.165.0",
 		"@clayui/toolbar": "^3.165.0",
+		"@liferay/layout-js-components-web": "*",
+		"frontend-js-web": "*",
 		"react": "18.2.0"
 	},
 	"description": "",

--- a/modules/apps/audiences/audiences-web/package.json
+++ b/modules/apps/audiences/audiences-web/package.json
@@ -9,7 +9,6 @@
 		"@clayui/list": "^3.165.0",
 		"@clayui/toolbar": "^3.165.0",
 		"@liferay/layout-js-components-web": "*",
-		"frontend-js-web": "*",
 		"react": "18.2.0"
 	},
 	"description": "",

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,0 +1,3 @@
+.min-h-0 {
+	min-height: 0;
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/edit_audiences_entry.jsp
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/edit_audiences_entry.jsp
@@ -15,7 +15,8 @@ renderResponse.setTitle(editAudiencesEntryDisplayContext.getTitle());
 
 <liferay-util:html-top>
 	<aui:style type="text/css">
-		.control-menu {
+		.control-menu,
+		.side-navigation-container {
 			display: none;
 		}
 	</aui:style>

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.scss
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.scss
@@ -1,0 +1,5 @@
+$toolbar-height: 55px;
+
+.audience-builder-content {
+	height: calc(100vh - #{$toolbar-height});
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
@@ -9,11 +9,12 @@ import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import ClayToolbar from '@clayui/toolbar';
-import {cancelDebounce, debounce} from 'frontend-js-web';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useState} from 'react';
 
 import AttributesSidebar from './components/AttributesSidebar';
 import {AudiencesCriteriaType} from './types';
+
+import './AudienceBuilder.scss';
 
 const NAME_MAX_LENGTH = 75;
 
@@ -35,45 +36,9 @@ export default function AudienceBuilder({
 	const [currentName, setCurrentName] = useState(
 		name || Liferay.Language.get('new-audience')
 	);
-	const [height, setHeight] = useState<string>();
-
-	const editorRef = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		const editor = editorRef.current;
-
-		if (!editor) {
-			return;
-		}
-
-		const updateHeight = () => {
-			setHeight(
-				`${Math.max(
-					0,
-					window.innerHeight - editor.getBoundingClientRect().top
-				)}px`
-			);
-		};
-
-		updateHeight();
-
-		const debouncedUpdateHeight = debounce(updateHeight, 100);
-
-		window.addEventListener('resize', debouncedUpdateHeight);
-
-		return () => {
-			cancelDebounce(debouncedUpdateHeight);
-
-			window.removeEventListener('resize', debouncedUpdateHeight);
-		};
-	}, []);
 
 	return (
-		<div
-			className="d-flex flex-column overflow-hidden"
-			ref={editorRef}
-			style={{height}}
-		>
+		<div className="d-flex flex-column overflow-hidden">
 			<ClayToolbar>
 				<ClayLayout.ContainerFluid size={false}>
 					<ClayToolbar.Nav>
@@ -121,7 +86,7 @@ export default function AudienceBuilder({
 				</ClayLayout.ContainerFluid>
 			</ClayToolbar>
 
-			<div className="d-flex flex-grow-1 min-h-0">
+			<div className="audience-builder-content d-flex">
 				<div
 					className="border-right d-flex flex-column px-4"
 					style={{width: SIDEBAR_WIDTH}}
@@ -131,7 +96,7 @@ export default function AudienceBuilder({
 					/>
 				</div>
 
-				<div className="flex-grow-1 min-h-0 overflow-auto p-4">
+				<div className="flex-grow-1 overflow-auto p-4">
 					<ClayForm.Group>
 						<label htmlFor={`${namespace}name`}>
 							{Liferay.Language.get('name')}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
@@ -9,17 +9,25 @@ import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import ClayToolbar from '@clayui/toolbar';
-import React, {useState} from 'react';
+import {cancelDebounce, debounce} from 'frontend-js-web';
+import React, {useEffect, useRef, useState} from 'react';
+
+import AttributesSidebar from './components/AttributesSidebar';
+import {AudiencesCriteriaType} from './types';
 
 const NAME_MAX_LENGTH = 75;
 
+const SIDEBAR_WIDTH = '25%';
+
 interface IProps {
+	audiencesCriteriaTypes?: AudiencesCriteriaType[];
 	backURL?: string;
 	name?: string;
 	namespace?: string;
 }
 
 export default function AudienceBuilder({
+	audiencesCriteriaTypes = [],
 	backURL,
 	name,
 	namespace = '',
@@ -27,9 +35,45 @@ export default function AudienceBuilder({
 	const [currentName, setCurrentName] = useState(
 		name || Liferay.Language.get('new-audience')
 	);
+	const [height, setHeight] = useState<string>();
+
+	const editorRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const editor = editorRef.current;
+
+		if (!editor) {
+			return;
+		}
+
+		const updateHeight = () => {
+			setHeight(
+				`${Math.max(
+					0,
+					window.innerHeight - editor.getBoundingClientRect().top
+				)}px`
+			);
+		};
+
+		updateHeight();
+
+		const debouncedUpdateHeight = debounce(updateHeight, 100);
+
+		window.addEventListener('resize', debouncedUpdateHeight);
+
+		return () => {
+			cancelDebounce(debouncedUpdateHeight);
+
+			window.removeEventListener('resize', debouncedUpdateHeight);
+		};
+	}, []);
 
 	return (
-		<>
+		<div
+			className="d-flex flex-column overflow-hidden"
+			ref={editorRef}
+			style={{height}}
+		>
 			<ClayToolbar>
 				<ClayLayout.ContainerFluid size={false}>
 					<ClayToolbar.Nav>
@@ -77,12 +121,17 @@ export default function AudienceBuilder({
 				</ClayLayout.ContainerFluid>
 			</ClayToolbar>
 
-			<ClayLayout.Row className="m-0">
-				<ClayLayout.Col className="border-right p-4" md={3}>
-					<h4>{Liferay.Language.get('attributes-types')}</h4>
-				</ClayLayout.Col>
+			<div className="d-flex flex-grow-1 min-h-0">
+				<div
+					className="border-right d-flex flex-column px-4"
+					style={{width: SIDEBAR_WIDTH}}
+				>
+					<AttributesSidebar
+						audiencesCriteriaTypes={audiencesCriteriaTypes}
+					/>
+				</div>
 
-				<ClayLayout.Col className="p-4" md={9}>
+				<div className="flex-grow-1 min-h-0 overflow-auto p-4">
 					<ClayForm.Group>
 						<label htmlFor={`${namespace}name`}>
 							{Liferay.Language.get('name')}
@@ -104,8 +153,8 @@ export default function AudienceBuilder({
 							value={currentName}
 						/>
 					</ClayForm.Group>
-				</ClayLayout.Col>
-			</ClayLayout.Row>
-		</>
+				</div>
+			</div>
+		</div>
 	);
 }

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributesSidebar.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributesSidebar.tsx
@@ -1,0 +1,88 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayEmptyState from '@clayui/empty-state';
+import ClayForm, {ClaySelectWithOption} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import ClayList from '@clayui/list';
+import {SearchForm} from '@liferay/layout-js-components-web';
+import React, {useState} from 'react';
+
+import {AudiencesCriteriaType} from '../types';
+
+interface IProps {
+	audiencesCriteriaTypes: AudiencesCriteriaType[];
+}
+
+export default function AttributesSidebar({audiencesCriteriaTypes}: IProps) {
+	const [selectedIndex, setSelectedIndex] = useState(0);
+	const [query, setQuery] = useState('');
+
+	const normalizedQuery = query.trim().toLowerCase();
+
+	const audiencesCriterias =
+		audiencesCriteriaTypes[selectedIndex]?.audiencesCriterias?.filter(
+			(audiencesCriteria) =>
+				audiencesCriteria.label.toLowerCase().includes(normalizedQuery)
+		) ?? [];
+
+	return (
+		<div className="d-flex flex-column flex-grow-1 min-h-0">
+			<h4 className="my-3">{Liferay.Language.get('attributes-types')}</h4>
+
+			<ClayForm.Group>
+				<ClaySelectWithOption
+					aria-label={Liferay.Language.get('attributes-types')}
+					onChange={(event) => {
+						setSelectedIndex(Number(event.target.value));
+						setQuery('');
+					}}
+					options={audiencesCriteriaTypes.map(
+						(audiencesCriteriaType, index) => ({
+							label: audiencesCriteriaType.label,
+							value: index,
+						})
+					)}
+					value={selectedIndex}
+				/>
+			</ClayForm.Group>
+
+			<SearchForm
+				className="mb-3"
+				label={Liferay.Language.get('search-attributes')}
+				onChange={setQuery}
+			/>
+
+			{audiencesCriterias.length ? (
+				<div className="flex-grow-1 min-h-0 overflow-auto">
+					<ClayList>
+						{audiencesCriterias.map((audiencesCriteria) => (
+							<ClayList.Item
+								className="align-items-center border-0"
+								flex
+								key={audiencesCriteria.key}
+							>
+								<ClayList.ItemField>
+									<ClayIcon symbol={audiencesCriteria.icon} />
+								</ClayList.ItemField>
+
+								<ClayList.ItemField expand>
+									{audiencesCriteria.label}
+								</ClayList.ItemField>
+							</ClayList.Item>
+						))}
+					</ClayList>
+				</div>
+			) : (
+				<ClayEmptyState
+					description={Liferay.Language.get(
+						'no-attributes-were-found'
+					)}
+					small
+				/>
+			)}
+		</div>
+	);
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributesSidebar.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributesSidebar.tsx
@@ -29,7 +29,7 @@ export default function AttributesSidebar({audiencesCriteriaTypes}: IProps) {
 		) ?? [];
 
 	return (
-		<div className="d-flex flex-column flex-grow-1 min-h-0">
+		<div className="d-flex flex-column flex-grow-0 h-100">
 			<h4 className="my-3">{Liferay.Language.get('attributes-types')}</h4>
 
 			<ClayForm.Group>
@@ -56,7 +56,7 @@ export default function AttributesSidebar({audiencesCriteriaTypes}: IProps) {
 			/>
 
 			{audiencesCriterias.length ? (
-				<div className="flex-grow-1 min-h-0 overflow-auto">
+				<div className="overflow-auto">
 					<ClayList>
 						{audiencesCriterias.map((audiencesCriteria) => (
 							<ClayList.Item

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/types.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/types.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export interface AudiencesCriteria {
+	icon: string;
+	key: string;
+	label: string;
+	operators: string[];
+	options: Array<{label: string; value: string}>;
+	type: string;
+}
+
+export interface AudiencesCriteriaType {
+	audiencesCriterias: AudiencesCriteria[];
+	label: string;
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "f6b6644abbbf1b37b57fbf465c4d6c319cb5d535",
+	"@generated": "c243cbb320ef87bde7837fdb9425adb7d184f2d1",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -11,6 +11,15 @@
 		"module": "es2022",
 		"moduleResolution": "node",
 		"paths": {
+			"@liferay/layout-js-components-web": [
+				"../../../../../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-js-web": [
+				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/index.d.ts"
+			],
+			"frontend-js-web/legacy": [
+				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/legacy/index.ts"
+			]
 		},
 		"rootDir": "../../../../../../../..",
 		"skipLibCheck": true,
@@ -28,5 +37,11 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
+		}
 	]
 }

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "c243cbb320ef87bde7837fdb9425adb7d184f2d1",
+	"@generated": "64817cbd6cd23847388a173339b886903b702e78",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -13,12 +13,6 @@
 		"paths": {
 			"@liferay/layout-js-components-web": [
 				"../../../../../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
-			],
-			"frontend-js-web": [
-				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/index.d.ts"
-			],
-			"frontend-js-web/legacy": [
-				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/legacy/index.ts"
 			]
 		},
 		"rootDir": "../../../../../../../..",
@@ -39,9 +33,6 @@
 	"references": [
 		{
 			"path": "../../../../../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
-		},
-		{
-			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}
 	]
 }

--- a/modules/apps/audiences/audiences-web/test/js/AudienceBuilder.test.tsx
+++ b/modules/apps/audiences/audiences-web/test/js/AudienceBuilder.test.tsx
@@ -10,8 +10,8 @@ import React from 'react';
 import AudienceBuilder from '../../src/main/resources/META-INF/resources/js/AudienceBuilder';
 
 describe('AudienceBuilder', () => {
-	it('renders the editor shell, updates the title from the name, and links back', async () => {
-		const {getByLabelText, getByRole, getByText, queryByText} = render(
+	it('renders editor, updates name, back and cancel link to backURL', async () => {
+		const {getByLabelText, getByText, queryByText} = render(
 			<AudienceBuilder backURL="/back" namespace="_test_" />
 		);
 
@@ -23,7 +23,7 @@ describe('AudienceBuilder', () => {
 		expect(getByLabelText('back').getAttribute('href')).toBe('/back');
 		expect(getByText('cancel').getAttribute('href')).toBe('/back');
 
-		const input = getByRole('textbox');
+		const input = getByLabelText('name');
 
 		expect(input.getAttribute('name')).toBe('_test_name');
 		expect(input.getAttribute('maxLength')).toBe('75');

--- a/modules/apps/audiences/audiences-web/test/js/components/AttributesSidebar.test.tsx
+++ b/modules/apps/audiences/audiences-web/test/js/components/AttributesSidebar.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import AttributesSidebar from '../../../src/main/resources/META-INF/resources/js/components/AttributesSidebar';
+
+const AUDIENCES_CRITERIA_TYPES = [
+	{
+		audiencesCriterias: [
+			{
+				icon: 'user',
+				key: 'age',
+				label: 'Age',
+				operators: [],
+				options: [],
+				type: 'number',
+			},
+			{
+				icon: 'user',
+				key: 'city',
+				label: 'City',
+				operators: [],
+				options: [],
+				type: 'string',
+			},
+		],
+		label: 'User',
+	},
+	{
+		audiencesCriterias: [
+			{
+				icon: 'globe',
+				key: 'browser',
+				label: 'Browser',
+				operators: [],
+				options: [],
+				type: 'string',
+			},
+		],
+		label: 'Session',
+	},
+];
+
+describe('AttributesSidebar', () => {
+	it('lists and filters the attributes', async () => {
+		render(
+			<AttributesSidebar
+				audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
+			/>
+		);
+
+		expect(screen.getByText('Age')).toBeTruthy();
+		expect(screen.getByText('City')).toBeTruthy();
+		expect(screen.queryByText('Browser')).toBeNull();
+
+		await userEvent.selectOptions(
+			screen.getByLabelText('attributes-types'),
+			screen.getByRole('option', {name: 'Session'})
+		);
+
+		expect(screen.getByText('Browser')).toBeTruthy();
+		expect(screen.queryByText('Age')).toBeNull();
+
+		await userEvent.selectOptions(
+			screen.getByLabelText('attributes-types'),
+			screen.getByRole('option', {name: 'User'})
+		);
+
+		await userEvent.type(screen.getByLabelText('search-attributes'), 'cit');
+
+		await waitFor(() => expect(screen.queryByText('Age')).toBeNull());
+
+		expect(screen.getByText('City')).toBeTruthy();
+
+		await userEvent.clear(screen.getByLabelText('search-attributes'));
+		await userEvent.type(screen.getByLabelText('search-attributes'), 'zzz');
+
+		await waitFor(() =>
+			expect(screen.getByText('no-attributes-were-found')).toBeTruthy()
+		);
+	});
+});

--- a/modules/apps/audiences/audiences-web/test/tsconfig.json
+++ b/modules/apps/audiences/audiences-web/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "b59e5d6ff0f6899c743c5aa689f11aadd02db3ef",
+	"@generated": "ad8d3366dd1ba12c82db3f055f4d01c15d13719c",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -11,6 +11,15 @@
 		"module": "es2022",
 		"moduleResolution": "node",
 		"paths": {
+			"@liferay/layout-js-components-web": [
+				"../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-js-web": [
+				"../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/index.d.ts"
+			],
+			"frontend-js-web/legacy": [
+				"../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/legacy/index.ts"
+			]
 		},
 		"rootDir": "../../../..",
 		"skipLibCheck": true,
@@ -30,5 +39,11 @@
 		"../src/**/*.tsx"
 	],
 	"references": [
+		{
+			"path": "../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
+		}
 	]
 }

--- a/modules/apps/audiences/audiences-web/test/tsconfig.json
+++ b/modules/apps/audiences/audiences-web/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "ad8d3366dd1ba12c82db3f055f4d01c15d13719c",
+	"@generated": "df59c713b3b691c7cd600f88ab3fe2309dbdcc64",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -13,12 +13,6 @@
 		"paths": {
 			"@liferay/layout-js-components-web": [
 				"../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
-			],
-			"frontend-js-web": [
-				"../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/index.d.ts"
-			],
-			"frontend-js-web/legacy": [
-				"../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/legacy/index.ts"
 			]
 		},
 		"rootDir": "../../../..",
@@ -41,9 +35,6 @@
 	"references": [
 		{
 			"path": "../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
-		},
-		{
-			"path": "../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}
 	]
 }


### PR DESCRIPTION
WIP: removes the dynamic `setHeight` logic from the Audience Builder editor and replaces it with a fixed `calc(100vh - 55px)` content height defined in a new `AudienceBuilder.scss` (55px = toolbar height). Also drops the now-unused `frontend-js-web` dependency and regenerates the tsconfig files.